### PR TITLE
Changed Customer PriorityGroups to List of Ints rather than string

### DIFF
--- a/NCS.DSS.FunctionalTests/Models/Customer.cs
+++ b/NCS.DSS.FunctionalTests/Models/Customer.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace FunctionalTests.Models
 {
@@ -21,7 +22,7 @@ namespace FunctionalTests.Models
         public string IntroducedByAdditionalInfo { get; set; }
         public string LastModifiedDate { get; set; }
         public string LastModifiedTouchpointID { get; set; }
-        public string PriorityGroups { get; set; }
+        public List<int> PriorityGroups { get; set; }
 
     }
 }

--- a/NCS.DSS.FunctionalTests/StepDefs/Steps.cs
+++ b/NCS.DSS.FunctionalTests/StepDefs/Steps.cs
@@ -163,7 +163,7 @@ namespace FunctionalTests.StepDefs
             var customer = new Customer();
             customer.GivenName = givenName;
             customer.FamilyName = "Smith";
-            customer.PriorityGroups = "[ 1, 3 ]";
+            customer.PriorityGroups = new List<int> { 1, 3 };
             json = JsonConvert.SerializeObject(customer);
             response = RestHelper.Post(lastResourceName = constants.Customers, url, json, envSettings.TestEndpoint01, envSettings.SubscriptionKey);
             customerId = AssertAndExtract("CustomerId", response);


### PR DESCRIPTION
- This changes PriorityGroups to List<int> rather than string because since removing the local helper methods, the nuget package does not parse "[1,2]" as a List. 